### PR TITLE
remove gRPC PHP extension from build

### DIFF
--- a/php/Dockerfile
+++ b/php/Dockerfile
@@ -51,7 +51,7 @@ RUN apk add --no-cache ca-certificates wget gnupg && \
 RUN apk add --no-cache --virtual .phpize-deps $PHPIZE_DEPS \
     && curl -L -o /usr/local/bin/install-php-extensions https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions \
     && chmod +x /usr/local/bin/install-php-extensions \
-    && install-php-extensions bcmath curl dom exif fileinfo gd hash igbinary intl json mbstring mysqli opcache openssl pcre pdo_mysql pdo_sqlite redis shmop simplexml sodium soap sockets ssh2 tokenizer xml xmlreader xmlwriter zip zlib apcu ftp relay pspell pcntl mongodb ldap imap grpc gmp gettext excimer ev calendar xsl sqlsrv pdo_sqlsrv pdo_pgsql
+    && install-php-extensions bcmath curl dom exif fileinfo gd hash igbinary intl json mbstring mysqli opcache openssl pcre pdo_mysql pdo_sqlite redis shmop simplexml sodium soap sockets ssh2 tokenizer xml xmlreader xmlwriter zip zlib apcu ftp relay pspell pcntl mongodb ldap imap gmp gettext excimer ev calendar xsl sqlsrv pdo_sqlsrv pdo_pgsql
 
 # Install imagick manually for PHP 8.3
 RUN if [[ "$PHP_VERSION" == "8.3"* ]]; then \


### PR DESCRIPTION
## Summary
The **gRPC PHP extension** is currently causing significant delays during the build process. Installing the extension via `pecl install grpc` takes a long time and produces very large binaries, which negatively impacts CI build times.

Several upstream issues indicate that this is a known problem with the gRPC PHP extension build process.

Details;
https://github.com/ma-04/flywp-dockerfiles/actions/runs/23083888353/job/67057476647

## References
- https://github.com/grpc/grpc/issues/34278  
- https://github.com/grpc/grpc/pull/35404  
- https://github.com/grpc/grpc/issues/23626  
- https://stackoverflow.com/questions/69134390/docker-container-fails-to-build-when-installing-grpc  

## Problem
- `install-php-extensions install grpc` significantly increases CI build time.
- This negatively affects developer productivity and CI efficiency.

## Temporary Solution
This PR **removes the gRPC PHP extension from the build** to avoid the slow installation during CI.

## Future Improvements
We can reintroduce gRPC once we implement one of the following:

- **GitHub Actions caching** for compiled extensions
- **Prebuilt PHP extensions** in the base Docker image
- Use the new `pkg-config` / `with-grpc-dir` support once it becomes stable upstream

## Impact
- Faster CI builds
- Smaller Docker image layers
- No functional impact if gRPC is not currently required

## Notes
If gRPC functionality becomes required in the future, we should revisit this and implement a proper caching or prebuilt extension strategy.

Fixes; https://github.com/flywp/issues/issues/435
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Minor formatting update to build configuration.

---

**Note:** This release contains no functional changes or new features visible to end-users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->