### PR TITLE
fix: keep OLS cachedata owned by www-data across restarts

### DIFF
--- a/openlitespeed/entrypoint.sh
+++ b/openlitespeed/entrypoint.sh
@@ -23,6 +23,7 @@ usermod -u $PUID www-data
 chown -R www-data:www-data /var/www/html
 chown www-data:www-data /var/lib/php/sessions
 chown -R lsadm:lsadm /usr/local/lsws
+chown -R www-data:www-data /usr/local/lsws/cachedata
 
 # Start OpenLiteSpeed
 echo "Starting OpenLiteSpeed..."


### PR DESCRIPTION
The entrypoint's `chown -R lsadm:lsadm /usr/local/lsws` also re-owns the LiteSpeed cache store (`cachedata`) on every start. After a restart the pre-existing cache files are owned by `lsadm` while the OLS worker runs as `www-data`, so the worker can no longer `open()` them — producing `cachedata/priv/...: open() failed: Permission denied` on cache hits until the cache repopulates.

Re-chown `cachedata` back to `www-data` immediately after the lsws chown so cached entries stay readable by the worker across restarts. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup permissions for OpenLiteSpeed cache data, helping ensure reliable caching and server operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->